### PR TITLE
fix: relative paths for static assets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,11 +134,22 @@ fn render_page(md_path: &Path, tera: &Tera) -> Result<()> {
 
   fs::create_dir_all(out_path.parent().unwrap())?;
 
+  // Calculate root-relative prefix based on output depth.
+  // build/index.html        → "./"
+  // build/docs/index.html   → "../"
+  // build/a/b/index.html    → "../../"
+  let depth = out_path
+    .strip_prefix(BUILD_DIR).unwrap()
+    .parent().unwrap()
+    .components().count();
+  let root = if depth == 0 { "./".to_string() } else { "../".repeat(depth) };
+
   let template_name = format!("{}.html", page.template);
   let mut ctx = TeraCtx::new();
   ctx.insert("title", &page.title);
   ctx.insert("body", &page.body_html);
   ctx.insert("meta", &page.meta);
+  ctx.insert("root", &root);
 
   let rendered = tera
     .render(&template_name, &ctx)

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="not-found">
-  <img src="/logo.png" alt="ƒink">
+  <img src="{{ root }}logo.png" alt="ƒink">
   <h1>404</h1>
-  <p>That page doesn't exist. <a href="/">Go home</a>.</p>
+  <p>That page doesn't exist. <a href="{{ root }}">Go home</a>.</p>
 </div>
 {% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if title %}{{ title }} — ƒink{% else %}ƒink{% endif %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hack-font@3/build/web/hack.css">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ root }}favicon-32.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="{{ root }}favicon-192.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ root }}apple-touch-icon.png">
 
   <!-- Open Graph / social preview -->
   <meta property="og:type" content="website">
@@ -24,13 +24,13 @@
   <meta name="twitter:image" content="https://fink-lang.org/social.png">
 
   <meta name="description" content="A functional language that compiles to WasmGC.">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="{{ root }}style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a class="wordmark" href="/"><img src="/logo.png" alt="" class="wordmark-logo">ƒink</a>
-      <a href="/docs/">docs</a>
+      <a class="wordmark" href="{{ root }}"><img src="{{ root }}logo.png" alt="" class="wordmark-logo">ƒink</a>
+      <a href="{{ root }}docs/">docs</a>
       <a href="https://github.com/fink-lang" class="nav-icon" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg></a>
     </nav>
   </header>

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,9 +2,9 @@
 {% block content %}
 
 <section class="hero">
-  <h1 class="hero-wordmark"><img src="/logo.png" alt="" class="hero-logo">ƒink</h1>
+  <h1 class="hero-wordmark"><img src="{{ root }}logo.png" alt="" class="hero-logo">ƒink</h1>
   <p class="hero-tagline">A functional language that compiles to WasmGC.</p>
-  <a class="btn" href="/docs/">Read the docs</a>
+  <a class="btn" href="{{ root }}docs/">Read the docs</a>
   <a class="btn btn-outline" href="https://github.com/fink-lang/fink">View source</a>
 </section>
 


### PR DESCRIPTION
Use `{{ root }}` template variable instead of absolute `/` paths so the site works when deployed to a subpath (e.g. `/website/` on GitHub Pages).