### PR TITLE
fix: reset code/pre font-family to override browser default

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,6 +6,7 @@
 
 /* --- Reset / base ------------------------------------------- */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+code, pre, kbd, samp { font-family: var(--font-mono); }
 
 :root {
   --bg:        #ffffff;


### PR DESCRIPTION
Browser default stylesheet sets `tt, code, kbd, samp { font-family: monospace }` which was overriding `--font-mono` (Hack) on code elements. Added an explicit reset early in the stylesheet.