### PR TITLE
SVG renderer and syntax color variables

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -454,20 +454,51 @@ fn render(src: &str, anns: &mut Annotations) -> String {
   out
 }
 
-// ---- public entry point ---------------------------------------------------
+// ---- public entry points --------------------------------------------------
+
+fn collect(src: &str) -> Annotations {
+  let mut anns = Annotations::new();
+  collect_lexer_anns(src, &mut anns);
+  if let Ok(parse_result) = parser::parse(src) {
+    collect_ast_anns(&parse_result.root, &mut anns, 1);
+  }
+  anns
+}
 
 /// Highlight a Fink source snippet, returning an HTML fragment.
 /// Suitable for wrapping in `<pre><code>...</code></pre>`.
 pub fn highlight(src: &str) -> String {
-  let mut anns = Annotations::new();
+  let mut anns = collect(src);
+  render(src, &mut anns)
+}
 
-  // Lexer pass always runs (fallback if parse fails)
-  collect_lexer_anns(src, &mut anns);
+/// Return resolved annotation spans as (start, end, class) tuples.
+/// Spans are non-overlapping and sorted by position; gaps between spans
+/// are plain (unstyled) text.
+pub fn annotate(src: &str) -> Vec<(usize, usize, String)> {
+  let mut anns = collect(src);
+  anns.sort();
 
-  // AST pass if parse succeeds
-  if let Ok(parse_result) = parser::parse(src) {
-    collect_ast_anns(&parse_result.root, &mut anns, 1);
+  let mut result = Vec::new();
+  let mut cursor = 0usize;
+  let mut ann_idx = 0usize;
+
+  while cursor < src.len() {
+    while ann_idx < anns.anns.len() && anns.anns[ann_idx].end <= cursor {
+      ann_idx += 1;
+    }
+    let next = anns.anns[ann_idx..].iter().find(|a| a.start >= cursor);
+    match next {
+      None => break,
+      Some(ann) if ann.start > cursor => { cursor = ann.start; }
+      Some(ann) => {
+        let end = ann.end.min(src.len());
+        result.push((cursor, end, ann.class.to_string()));
+        cursor = end;
+        ann_idx += 1;
+      }
+    }
   }
 
-  render(src, &mut anns)
+  result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 mod highlight;
 mod markdown;
 mod serve;
+mod svg;
 
 use std::collections::HashMap;
 use std::fs;
@@ -43,10 +44,17 @@ fn main() -> Result<()> {
       serve::stop()?;
       return Ok(());
     }
+    Some("svg") => {
+      let path = args.get(2).expect("Usage: fink-site svg <file.fnk>");
+      let src = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {path}"))?;
+      print!("{}", svg::render_svg(&src));
+      return Ok(());
+    }
     Some("build") | None => {}
     Some(other) => {
       eprintln!("Unknown command: {other}");
-      eprintln!("Usage: fink-site [build | serve [port] | stop]");
+      eprintln!("Usage: fink-site [build | serve [port] | stop | svg <file>]");
       std::process::exit(1);
     }
   }

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,0 +1,164 @@
+// SVG renderer for syntax-highlighted Fink code.
+//
+// Reuses the highlight pipeline (lexer + AST annotations) and renders to an
+// SVG document with monospace text, using the same colour palette as the
+// website's CSS.
+//
+// Usage: cargo run -- svg <file.fnk>
+//        Writes SVG to stdout.
+
+use std::collections::HashMap;
+use std::fs;
+
+use crate::highlight;
+
+// ---- colour map (parsed from static/syntax-colors.css) ----------------------
+
+const SYNTAX_CSS_PATH: &str = "static/syntax-colors.css";
+
+/// Parse syntax-colors.css for --fink-* custom properties.
+/// Expects lines like: --fink-kw: #C586C0;
+/// Returns a map from token class name (e.g. "kw") to hex color.
+fn load_colors() -> HashMap<String, String> {
+  let css = fs::read_to_string(SYNTAX_CSS_PATH)
+    .unwrap_or_else(|e| panic!("failed to read {SYNTAX_CSS_PATH}: {e}"));
+
+  let mut map = HashMap::new();
+  for line in css.lines() {
+    let line = line.trim();
+    let Some(rest) = line.strip_prefix("--fink-") else { continue };
+    let Some((name, rest)) = rest.split_once(':') else { continue };
+    // Strip trailing comment (/* ... */) and semicolon
+    let value = rest.split("/*").next().unwrap_or(rest);
+    let color = value.trim().trim_end_matches(';').trim();
+    if color.starts_with('#') {
+      map.insert(name.to_string(), color.to_string());
+    }
+  }
+  map
+}
+
+// ---- SVG rendering ---------------------------------------------------------
+
+const FALLBACK_BG: &str = "#1F1F1F";
+const FALLBACK_TEXT: &str = "#D4D4D4";
+const FONT_FAMILY: &str = "Hack, Consolas, Menlo, Monaco, monospace";
+const FONT_SIZE: f64 = 14.0;
+const LINE_HEIGHT: f64 = 1.55;
+const CHAR_WIDTH: f64 = 8.4;   // approximate for 14px monospace
+const PAD_X: f64 = 16.0;
+const PAD_Y: f64 = 16.0;
+
+fn xml_escape(s: &str) -> String {
+  s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;")
+}
+
+/// Render a Fink source string as an SVG document.
+pub fn render_svg(src: &str) -> String {
+  let colors = load_colors();
+  let bg = colors.get("bg").map(|s| s.as_str()).unwrap_or(FALLBACK_BG);
+  let default_color = colors.get("text").map(|s| s.as_str()).unwrap_or(FALLBACK_TEXT);
+  let anns = highlight::annotate(src);
+
+  let lines: Vec<&str> = src.split('\n').collect();
+  let max_cols = lines.iter().map(|l| l.len()).max().unwrap_or(0);
+  let num_lines = lines.len();
+
+  let line_h = FONT_SIZE * LINE_HEIGHT;
+  let width = PAD_X * 2.0 + max_cols as f64 * CHAR_WIDTH;
+  let height = PAD_Y * 2.0 + num_lines as f64 * line_h;
+  let corner_r = 6.0;
+
+  let mut out = String::with_capacity(src.len() * 4);
+
+  // SVG header
+  out.push_str(&format!(
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {w} {h}\" width=\"{w}\" height=\"{h}\">\n",
+    w = width.ceil() as usize,
+    h = height.ceil() as usize,
+  ));
+  out.push_str(&format!(
+    "<rect width=\"100%\" height=\"100%\" rx=\"{corner_r}\" ry=\"{corner_r}\" fill=\"{bg}\"/>\n"
+  ));
+
+  // Build a byte-offset → (line, col) lookup
+  let mut line_starts: Vec<usize> = Vec::with_capacity(num_lines);
+  let mut offset = 0;
+  for line in &lines {
+    line_starts.push(offset);
+    offset += line.len() + 1; // +1 for \n
+  }
+
+  // Walk annotations, grouped by line for tspan output
+  let mut ann_idx = 0usize;
+
+  for (line_no, line_text) in lines.iter().enumerate() {
+    let line_start = line_starts[line_no];
+    let line_end = line_start + line_text.len();
+    let y = PAD_Y + (line_no as f64 + 0.8) * line_h;
+
+    out.push_str(&format!(
+      "<text x=\"{x}\" y=\"{y}\" fill=\"{default_color}\" font-family=\"{FONT_FAMILY}\" font-size=\"{FONT_SIZE}\" xml:space=\"preserve\">",
+      x = PAD_X,
+    ));
+
+    let mut cursor = line_start;
+
+    while cursor < line_end {
+      // Skip past annotations
+      while ann_idx < anns.len() && anns[ann_idx].1 <= cursor {
+        ann_idx += 1;
+      }
+
+      // Find next annotation that overlaps this line
+      let next = anns[ann_idx..].iter().find(|a| a.0 >= cursor && a.0 < line_end);
+
+      match next {
+        None => {
+          // Rest of line is plain text
+          out.push_str(&xml_escape(&src[cursor..line_end]));
+          cursor = line_end;
+        }
+        Some(&(start, _, _)) if start > cursor => {
+          // Plain text before annotation
+          out.push_str(&xml_escape(&src[cursor..start]));
+          cursor = start;
+        }
+        Some(&(_, end, ref class)) => {
+          let seg_end = end.min(line_end);
+          // Map highlight class names to CSS variable names where they differ
+          let var_name = match class.as_str() {
+            "fn"    => "call",
+            "str-e" => "str-esc",
+            "ph"    => "partial",
+            "wc"    => "wldcrd",
+            other   => other,
+          };
+          let color = colors.get(var_name)
+            .or_else(|| var_name.rsplit_once('-').and_then(|(base, _)| colors.get(base)))
+            .map(|s| s.as_str())
+            .unwrap_or(default_color);
+          let italic = class == "cmt";
+          if italic {
+            out.push_str(&format!(
+              "<tspan fill=\"{color}\" font-style=\"italic\">{}</tspan>",
+              xml_escape(&src[cursor..seg_end])
+            ));
+          } else {
+            out.push_str(&format!(
+              "<tspan fill=\"{color}\">{}</tspan>",
+              xml_escape(&src[cursor..seg_end])
+            ));
+          }
+          cursor = seg_end;
+          ann_idx += 1;
+        }
+      }
+    }
+
+    out.push_str("</text>\n");
+  }
+
+  out.push_str("</svg>\n");
+  out
+}

--- a/static/style.css
+++ b/static/style.css
@@ -15,8 +15,8 @@ code, pre, kbd, samp { font-family: var(--font-mono); }
   --accent:    #005f5f;
   --accent-h:  #004444;
   --border:    #e0e0e0;
-  --code-bg:   #1F1F1F;
-  --code-text: #d4d4d4;
+  --code-bg:   var(--fink-bg);
+  --code-text: var(--fink-text);
   --font-sans: "Inter", system-ui, sans-serif;
   --font-mono: "Hack", Consolas, Menlo, Monaco, monospace;
   --font-wordmark: "Inter", system-ui, sans-serif;
@@ -298,32 +298,31 @@ pre.code-block code {
 .taste pre.code-block { margin-bottom: 2rem; }
 
 /* --- Syntax token colours ----------------------------------- */
-/* These classes are emitted by src/highlight.rs               */
-.kw      { color: #C586C0; }                    /* fn, match, import, …  */
-.kw-b    { color: #569CD6; }                    /* true, false           */
-.ty      { color: #4EC9B0; }                    /* u8, f32, str, …       */
-.fn      { color: #DCDCAA; }                    /* function call name    */
-.blk     { color: #DCDCAA; }                    /* block name: filter, map, … */
-.tag     { color: #569CD6; }                    /* tagged literal/template */
-.prop    { color: #4FC1FF; }                    /* property name after . */
-.rec-key { color: #9CDCFE; }                    /* record key            */
-.ident   { color: #4FC1FF; }                    /* plain identifier      */
-.op      { color: #D4D4D4; }                    /* operators             */
-.op-asgn { color: #D4D4D4; }                    /* = assignment          */
-.op-pipe { color: #C586C0; }                    /* | pipe, |= binding    */
-.op-rng  { color: #D4D4D4; }                    /* .. ...                */
-.op-dot  { color: #D4D4D4; }                    /* . accessor dot        */
-.br      { color: #CCCCCC; }                    /* { } [ ] ( ) fallback  */
-.br-1    { color: #BDBB85; }                    /* depth 1 — gold        */
-.br-2    { color: #CC76D1; }                    /* depth 2 — orchid      */
-.br-3    { color: #4A9DF8; }                    /* depth 3 — blue        */
-.str     { color: #CE9178; }                    /* string content        */
-.str-e   { color: #D7BA7D; }                    /* ${ } interpolation / escape */
-.num     { color: #B5CEA8; }                    /* decimal numeric       */
-.num-b   { color: #D7BA7D; }                    /* hex/octal/binary numeric */
-.cmt     { color: #6A9955; font-style: italic; }/* comments              */
-.ph      { color: #C586C0; }                    /* ? placeholder         */
-.wc      { color: #C586C0; }                    /* _ wildcard            */
+/* Variables defined in syntax-colors.css                       */
+@import url("syntax-colors.css");
+
+.kw      { color: var(--fink-kw); }
+.kw-b    { color: var(--fink-kw-b); }
+.ty      { color: var(--fink-ty); }
+.fn      { color: var(--fink-call); }
+.blk     { color: var(--fink-blk); }
+.tag     { color: var(--fink-tag); }
+.prop    { color: var(--fink-prop); }
+.rec-key { color: var(--fink-rec-key); }
+.ident   { color: var(--fink-ident); }
+.op, .op-asgn, .op-rng, .op-dot { color: var(--fink-op); }
+.op-pipe { color: var(--fink-op-pipe); }
+.br      { color: var(--fink-br); }
+.br-1    { color: var(--fink-br-1); }
+.br-2    { color: var(--fink-br-2); }
+.br-3    { color: var(--fink-br-3); }
+.str     { color: var(--fink-str); }
+.str-e   { color: var(--fink-str-esc); }
+.num     { color: var(--fink-num); }
+.num-b   { color: var(--fink-num-b); }
+.cmt     { color: var(--fink-cmt); font-style: italic; }
+.ph      { color: var(--fink-partial); }
+.wc      { color: var(--fink-wldcrd); }
 
 /* --- 404 ---------------------------------------------------- */
 .not-found {

--- a/static/syntax-colors.css
+++ b/static/syntax-colors.css
@@ -1,0 +1,34 @@
+/* Fink syntax token colours.
+   Single source of truth — consumed by:
+     - static/style.css  (token classes reference these variables)
+     - src/svg.rs         (parsed at build time for SVG rendering)
+   Variables are emitted as CSS custom properties on :root.
+   Classes using them are defined in style.css. */
+
+:root {
+  --fink-bg:      #1F1F1F;                      /* code block background */
+  --fink-text:    #D4D4D4;                      /* default text          */
+
+  --fink-kw:      #C586C0;                      /* fn, match, import, …  */
+  --fink-kw-b:    #569CD6;                      /* true, false           */
+  --fink-ty:      #4EC9B0;                      /* u8, f32, str, …       */
+  --fink-call:    #DCDCAA;                      /* function call name    */
+  --fink-blk:     #DCDCAA;                      /* custom block name         */
+  --fink-tag:     #569CD6;                      /* tagged literal/template */
+  --fink-prop:    #4FC1FF;                      /* property name after . */
+  --fink-rec-key: #9CDCFE;                      /* record key            */
+  --fink-ident:   #4FC1FF;                      /* plain identifier      */
+  --fink-op:      #D4D4D4;                      /* operators             */
+  --fink-op-pipe: #C586C0;                      /* | pipe, |= binding    */
+  --fink-br:      #CCCCCC;                      /* { } [ ] ( ) fallback  */
+  --fink-br-1:    #BDBB85;                      /* depth 1 — gold        */
+  --fink-br-2:    #CC76D1;                      /* depth 2 — orchid      */
+  --fink-br-3:    #4A9DF8;                      /* depth 3 — blue        */
+  --fink-str:     #CE9178;                      /* string content        */
+  --fink-str-esc: #D7BA7D;                      /* ${ } interpolation / escape */
+  --fink-num:     #B5CEA8;                      /* decimal numeric       */
+  --fink-num-b:   #D7BA7D;                      /* hex/octal/binary numeric */
+  --fink-cmt:     #6A9955;                      /* comments              */
+  --fink-partial: #C586C0;                      /* ? placeholder         */
+  --fink-wldcrd:  #C586C0;                      /* _ wildcard            */
+}


### PR DESCRIPTION
## Summary

- Add `cargo run -- svg <file.fnk>` command that outputs syntax-highlighted Fink code as SVG to stdout
- Extract syntax token colours into `static/syntax-colors.css` as `--fink-*` CSS custom properties — single source of truth consumed by website CSS and SVG renderer

## Test plan

- [x] SVG output renders correctly with syntax colours from `syntax-colors.css`
- [x] Website code blocks unchanged (verified identical CSS variable resolution)
- [ ] CI build passes