### PR TITLE
Add install-deps, clean commands; bump playground v1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -1771,18 +1771,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [package.metadata.assets.playground]
 url = "https://github.com/fink-lang/playground/releases/download/{version}/playground.tar.gz"
-version = "v1.9.0"
+version = "v1.10.0"
 dest = ".deps/playground"
 
 [package.metadata.assets.brand]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ fn main() -> Result<()> {
       print!("{}", svg::render_svg(&src));
       return Ok(());
     }
+    Some("install-deps") => {
+      install_deps()?;
+      return Ok(());
+    }
     Some("update-deps") => {
       update_deps()?;
       return Ok(());
@@ -67,10 +71,14 @@ fn main() -> Result<()> {
       check_deps()?;
       return Ok(());
     }
+    Some("clean") => {
+      clean()?;
+      return Ok(());
+    }
     Some("build") | None => {}
     Some(other) => {
       eprintln!("Unknown command: {other}");
-      eprintln!("Usage: fink-site [build | serve [port] | stop | update-deps | check-deps | svg <file>]");
+      eprintln!("Usage: fink-site [build | serve [port] | stop | install-deps | update-deps | check-deps | clean | svg <file>]");
       std::process::exit(1);
     }
   }
@@ -388,17 +396,8 @@ fn github_repo_from_url(url: &str) -> Option<String> {
   }
 }
 
-/// Run `cargo update` and download asset dependencies.
-fn update_deps() -> Result<()> {
-  println!("Running cargo update…");
-  let status = std::process::Command::new("cargo")
-    .arg("update")
-    .status()
-    .context("failed to run cargo update")?;
-  if !status.success() {
-    anyhow::bail!("cargo update failed");
-  }
-
+/// Fetch pinned asset dependencies into .deps/.
+fn fetch_asset_deps() -> Result<()> {
   let assets = parse_asset_deps()?;
 
   for dep in &assets {
@@ -432,6 +431,37 @@ fn update_deps() -> Result<()> {
     println!("No asset dependencies found in Cargo.toml");
   }
 
+  Ok(())
+}
+
+/// Install pinned dependencies (asset deps only, no cargo update).
+fn install_deps() -> Result<()> {
+  fetch_asset_deps()
+}
+
+/// Update all dependencies: cargo update + re-fetch asset deps.
+fn update_deps() -> Result<()> {
+  println!("Running cargo update…");
+  let status = std::process::Command::new("cargo")
+    .arg("update")
+    .status()
+    .context("failed to run cargo update")?;
+  if !status.success() {
+    anyhow::bail!("cargo update failed");
+  }
+
+  fetch_asset_deps()
+}
+
+/// Remove all build output.
+fn clean() -> Result<()> {
+  let build_dir = "build";
+  if Path::new(build_dir).exists() {
+    fs::remove_dir_all(build_dir).context("failed to remove build dir")?;
+    println!("Removed {build_dir}/");
+  } else {
+    println!("Nothing to clean.");
+  }
   Ok(())
 }
 
@@ -552,6 +582,20 @@ fn check_deps() -> Result<()> {
       None => {
         println!("  {} {} (failed to query GitHub API)", dep.name, dep.version);
       }
+    }
+  }
+
+  // Check crates.io dependencies via cargo outdated
+  println!();
+  let outdated = std::process::Command::new("cargo")
+    .args(["outdated", "--root-deps-only"])
+    .status();
+
+  match outdated {
+    Ok(s) if s.success() => {}
+    Ok(_) => { all_current = false; }
+    Err(_) => {
+      println!("  cargo outdated not installed — run: cargo install cargo-outdated");
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `install-deps` command: fetch pinned asset deps to `.deps/` without running `cargo update`
- Add `clean` command: remove all build output (`build/`)
- Split `update-deps`: now runs `cargo update` + re-fetch (previously conflated install and update)
- Add `cargo outdated` check to `check-deps` for crates.io dependencies
- Bump playground to v1.10.0

Full command set:
| Command | What it does |
|---|---|
| `install-deps` | Fetch pinned asset deps to `.deps/` |
| `update-deps` | `cargo update` + re-fetch asset deps |
| `check-deps` | Check all deps for newer releases |
| `clean` | Remove `build/` |
| `build` | Build the site |
| `serve` | Build + start dev server |

## Test plan

- [ ] `cargo run -- install-deps` fetches to `.deps/` without updating Cargo.lock
- [ ] `cargo run -- update-deps` runs cargo update then fetches
- [ ] `cargo run -- check-deps` reports all deps including cargo outdated
- [ ] `cargo run -- clean` removes `build/`
- [ ] `cargo run -- build` works after clean