### PR TITLE
Update deps, add Makefile, simplify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@
 #
 # On every push / PR: build and verify output exists.
 # On push to main: also deploy to GitHub Pages.
-#
-# The fink compiler is checked out side-by-side from main
-# to satisfy the path dependency in Cargo.toml.
 
 name: ci
 
@@ -19,15 +16,6 @@ jobs:
     steps:
       - name: Check out website
         uses: actions/checkout@v4
-        with:
-          path: website
-
-      - name: Check out fink compiler
-        uses: actions/checkout@v4
-        with:
-          repository: fink-lang/fink
-          ref: main
-          path: fink
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -35,31 +23,22 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('website/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
-      - name: Fetch dependencies
-        working-directory: website
-        run: cargo run --release -- update-deps
+      - name: Install dependencies
+        run: make deps-install
 
       - name: Build site
-        working-directory: website
-        run: cargo run --release
+        run: make build
 
-      - name: Verify output
-        working-directory: website
-        run: |
-          test -f build/site/index.html
-          test -f build/site/docs/index.html
-          test -f build/site/404.html
-          test -f build/site/CNAME
-          test -f build/site/playground/index.html
-          test -f build/site/playground/playground.js
+      - name: Test
+        run: make test
 
       - name: Upload pages artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: website/build/site
+          path: build/site
 
   deploy:
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # fink-site — project rules
 
+## Commands
+
+All commands are available via `make`:
+
+| Target | Description |
+|---|---|
+| `make deps-check` | Check for outdated dependencies (asset releases + cargo crates) |
+| `make deps-update` | Update all dependencies (`cargo update` + re-fetch assets) |
+| `make deps-install` | Fetch pinned asset dependencies to `.deps/` (no `cargo update`) |
+| `make clean` | Remove `build/` |
+| `make build` | Build the site (`--release`) |
+| `make test` | Verify expected output files exist (assumes prior `build`) |
+| `make serve` | Build + start dev server at http://localhost:8080/ |
+
 ## Dependencies
 
 All dependency versions are declared in one place:
@@ -7,17 +21,10 @@ All dependency versions are declared in one place:
 - **Rust crates**: `Cargo.toml` `[dependencies]`
 - **Asset dependencies** (e.g. playground, brand): `Cargo.toml` `[package.metadata.assets.<name>]`
 
-### Updating dependencies
-
-Run `cargo run -- update-deps` to update all dependencies:
-
-1. Runs `cargo update` (Rust crates)
-2. Downloads asset dependencies from GitHub releases into `.deps/`
-
 ### Build vs fetch
 
-- `cargo run` (or `cargo run -- build`) builds with what is already in `.deps/`. It will error if a referenced asset is missing.
-- `cargo run -- update-deps` fetches/updates dependencies. It does not build.
+- `make build` builds with what is already in `.deps/`. It will error if a referenced asset is missing.
+- `make deps-install` fetches pinned assets. `make deps-update` also runs `cargo update`.
 - A clean build should never fetch dependencies.
 
 ## Project layout
@@ -32,7 +39,7 @@ static/             # static files copied verbatim to build/site/
                     # (brand assets here are fallbacks, overridden by .deps/brand/)
 ```
 
-The dev server (`cargo run -- serve`) serves from `build/site/`.
+The dev server (`make serve`) serves from `build/site/`.
 
 ## Brand assets
 
@@ -51,3 +58,7 @@ asset_dir: playground                # copies runtime files to build/site/<path>
 ```
 
 The fragment HTML is injected at build time via `{{ fragment | safe }}` in the template.
+
+## Session wrap-up
+
+Before wrapping up, always kill the dev server if it's running (e.g. `lsof -ti:8080 | xargs kill`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 [[package]]
 name = "fink"
 version = "0.0.0"
-source = "git+https://github.com/fink-lang/fink.git?tag=v0.1.0#1a61a6b21aa0ad51c2f03e4062df64f774a17ae1"
+source = "git+https://github.com/fink-lang/fink.git?tag=v0.2.0#537724226857ce287deb080a78cfd5dee7ff3bac"
 dependencies = [
  "dap",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [package.metadata.assets.playground]
 url = "https://github.com/fink-lang/playground/releases/download/{version}/playground.tar.gz"
-version = "v1.10.0"
+version = "v1.10.2"
 dest = ".deps/playground"
 
 [package.metadata.assets.brand]
@@ -14,7 +14,7 @@ version = "v1.0.0"
 dest = ".deps/brand"
 
 [dependencies]
-fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.1.0" }
+fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.2.0" }
 pulldown-cmark = "0.13"
 tera = "1"
 walkdir = "2"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: deps-check deps-update deps-install clean build test serve
+
+deps-check:
+	cargo run -- check-deps
+
+deps-update:
+	cargo run -- update-deps
+
+deps-install:
+	cargo run -- install-deps
+
+clean:
+	cargo run -- clean
+
+build:
+	cargo run --release -- build
+
+test:
+	test -f build/site/index.html
+	test -f build/site/docs/index.html
+	test -f build/site/404.html
+	test -f build/site/CNAME
+	test -f build/site/playground/index.html
+	test -f build/site/playground/playground.js
+
+serve:
+	cargo run -- serve


### PR DESCRIPTION
## Summary
- Bump fink v0.1.0 → v0.2.0, playground v1.10.0 → v1.10.2
- Add Makefile with standard targets (`deps-check`, `deps-update`, `deps-install`, `clean`, `build`, `test`, `serve`)
- Simplify CI workflow to call `make` targets instead of direct `cargo run` commands
- Remove dead fink compiler checkout from CI (git dep replaced the old path dep)
- Update CLAUDE.md with full command reference

## Test plan
- [x] `make clean && make build && make test` passes locally
- [ ] CI passes on this branch