### PR TITLE
feat: bump playground v1.10.2 → v1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [package.metadata.assets.playground]
 url = "https://github.com/fink-lang/playground/releases/download/{version}/playground.tar.gz"
-version = "v1.10.2"
+version = "v1.11.0"
 dest = ".deps/playground"
 
 [package.metadata.assets.brand]


### PR DESCRIPTION
## Summary
- Update playground dependency from v1.10.2 to v1.11.0

## Test plan
- [x] `make deps-install` fetches v1.11.0
- [x] `make build` succeeds
- [x] `make test` passes