### PR TITLE
Bump fink v0.2.0 → v0.69.0, playground v1.11.0 → v1.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,15 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,27 +220,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
+checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
+checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
+checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -257,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
+checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -268,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
+checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -296,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
+checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -309,24 +300,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
+checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
+checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
+checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -336,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
+checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -348,15 +339,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
+checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
+checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -365,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.1"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
+checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
 
 [[package]]
 name = "crc32fast"
@@ -543,14 +534,16 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 [[package]]
 name = "fink"
 version = "0.0.0"
-source = "git+https://github.com/fink-lang/fink.git?tag=v0.2.0#537724226857ce287deb080a78cfd5dee7ff3bac"
+source = "git+https://github.com/fink-lang/fink.git?tag=v0.69.0#94ed654681fd72bd2be057b5ce7e33f7d587904c"
 dependencies = [
  "dap",
+ "gimli 0.33.0",
  "tokio",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wasmprinter",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter 0.248.0",
  "wasmtime",
+ "wast",
  "wat",
 ]
 
@@ -807,6 +800,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -873,20 +871,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -961,10 +945,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1069,12 +1055,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.38.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "memchr",
 ]
@@ -1277,9 +1263,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
+checksum = "b9326e3a0093d170582cf64ed9e4cf253b8aac155ec4a294ff62330450bbf094"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1289,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
+checksum = "00c6433917e3789605b1f4cd2a589f637ff17212344e7fa5ba99544625ba52c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1353,15 +1339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1470,12 +1447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,19 +1518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,19 +1542,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1744,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "pin-project-lite",
 ]
@@ -1833,12 +1781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1903,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1913,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1926,31 +1868,27 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-compose"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
+checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
 dependencies = [
  "anyhow",
  "heck",
- "im-rc",
  "indexmap",
  "log",
  "petgraph",
- "serde",
- "serde_derive",
- "serde_yaml",
  "smallvec",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wat",
 ]
 
@@ -1966,22 +1904,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -2010,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags",
  "hashbrown 0.16.1",
@@ -2023,31 +1961,44 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags",
+ "hashbrown 0.17.0",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
+checksum = "372db8bbad8ec962038101f75ab2c3ffcd18797d7d3ae877a58ab9873cd0c4bd"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2078,8 +2029,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -2098,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
+checksum = "1e15aa0d1545e48d9b25ca604e9e27b4cd6d5886d30ac5787b57b3a2daf85b57"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2120,18 +2071,18 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wasmprinter",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
+ "wasmprinter 0.246.2",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
+checksum = "5441170843ac2ab28a1d7646b04a93a46d63bd4083274fd246c6a80189b37767"
 dependencies = [
  "base64",
  "directories-next",
@@ -2149,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
+checksum = "c136cb0d2d47850d6d04a58157130ac98b0df4c17626cd30b083d26b607b7027"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2159,20 +2110,20 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
+checksum = "49df3d3b4fa2119c6fd161e475b4e21aaefb51d082353b922b433bea37facc65"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
+checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -2182,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
+checksum = "98c032f422e39061dfc43f32190c0a3526b04161ec4867f362958f3fe9d1fe29"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2200,7 +2151,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -2209,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c8b2c9704eb1f33ead025ec16038277ccb63d0a14c31e99d5b765d7c36da55"
+checksum = "d8dd76d80adf450cc260ba58f23c28030401930b19149695b1d121f7d621e791"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2224,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
+checksum = "ab453cc600b28ee5d3f9495aa6d4cb2c81eda40903e9287296b548fba8b2391d"
 dependencies = [
  "cc",
  "object",
@@ -2236,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3606662c156962d096be3127b8b8ae8ee2f8be3f896dad29259ff01ddb64abfd"
+checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2248,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
+checksum = "f1dfe405bd6adb1386d935a30f16a236bd4ef0d3c383e7cbbab98d063c9d9b73"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2261,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b0a5dab02a8fb527f547855ecc0e05f9fdc3d5bd57b8b080349408f9a6cece"
+checksum = "2a9b9165fc45d42c81edfe3e9cb458e58720594ad5db6553c4079ea041a4a581"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2272,16 +2223,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
+checksum = "95f439b70ba3855a8c808d2cd798eef79bcd389f78aa48a8a694ea8e2904410c"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -2289,36 +2240,36 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
+checksum = "17c7ced16dc16d2027f9f8d3a503e191dcce0f53fe9218e7990135b31f8f6fdb"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.245.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "248.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
  "wast",
 ]
@@ -2356,9 +2307,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.1"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
+checksum = "6da7c536f3cfe5ff63537f795902fed56b8b5adcc7a87843a86dd8d4e57a7946"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -2367,7 +2318,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -2549,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -2563,7 +2514,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [package.metadata.assets.playground]
 url = "https://github.com/fink-lang/playground/releases/download/{version}/playground.tar.gz"
-version = "v1.11.0"
+version = "v1.16.1"
 dest = ".deps/playground"
 
 [package.metadata.assets.brand]
@@ -14,7 +14,7 @@ version = "v1.0.0"
 dest = ".deps/brand"
 
 [dependencies]
-fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.2.0" }
+fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.69.0" }
 pulldown-cmark = "0.13"
 tera = "1"
 walkdir = "2"

--- a/content/docs/language/index.md
+++ b/content/docs/language/index.md
@@ -58,19 +58,21 @@ false
 
 ### Integers
 
-Integer types are inferred from the literal's value and sign (the values below show the inferred type — type information isn't surfaced in tooling yet). Underscores separate digit groups and are ignored.
+Integer types are inferred from the literal's *shape* and value (the values below show the inferred type — type information isn't surfaced in tooling yet). Underscores separate digit groups and are ignored.
+
+Decimal literals belong to the **math family** (signed, mix freely with floats). Hex / octal / binary literals belong to the **bits family** (unsigned, used for masks and bit patterns; don't mix with the math family). Width is the smallest type that fits the literal's value (signed range for signed literals, unsigned range for unsigned). To convert across families, use the std-lib helpers `int(x)` / `uint(x)` from `std/math`.
 
 ```fink
-1_234_567              # u32
-+1                     # i8
+1_234_567              # i32  — bare decimals are signed
++1                     # i8   — sign prefix forces signed
 -1                     # i8
-0xFF                   # u8
-+0xFF                  # i8
+0xFF                   # u8   — hex/oct/bin are unsigned
++0xFF                  # i8   — sign prefix forces signed (overrides bits family)
 0xFfFf                 # u16
 0xFFFF_FFFF            # u32
 0xFFFF_FFFF_FFFF_FFFF  # u64
-0o_1234_5670           # octal
-0b_0101_1111           # binary
+0o_1234_5670           # octal — unsigned by shape
+0b_0101_1111           # binary — unsigned by shape
 ```
 
 ### Floats and decimals
@@ -310,6 +312,7 @@ a >>> b                  # rotate right
 ```fink
 0..10                    # 0 inclusive, 10 exclusive
 0...10                   # 0 inclusive, 10 inclusive
+-3..                     # open ended from -3 onwards
 
 1 + 2..3 + 4             # (1 + 2)..(3 + 4) — `..` binds looser than arithmetic
 (1 + 2)..(3 + 4)         # parens optional for clarity
@@ -812,45 +815,6 @@ foo bar,
 ```
 
 For inline statement separation with `;` see [Precedence and grouping](#precedence-and-grouping).
-
----
-
-## Types *(work in progress)*
-
-```fink
-# product types
-Point = type: u8, u8
-Circle = type: {x: u8, y: u8, r: u8}
-
-# sum types / variants
-Result = variant T, E:
-  Ok T
-  Err E
-
-Shape = variant:
-  Circle {x: u8, y: u8, r: u8}
-  Rect {x: u8, y: u8, w: u8, h: u8}
-  Nil ()
-
-# opaque types
-UserId = type: ..u64
-
-# generic types
-Option = variant T:
-  Some T
-  None
-```
-
-Construction and matching:
-
-```fink
-circle = Circle {x: 1, y: 2, r: 5}
-some = Some 42
-
-match opt:
-  Some x: x
-  None: 0
-```
 
 ---
 

--- a/content/docs/roadmap/index.md
+++ b/content/docs/roadmap/index.md
@@ -44,9 +44,9 @@ with db_ctx:
 
 Concept: see the [Execution Model](../execution-model/) §7.
 
-## Missing arithmetic operators
+## Float exponentiation
 
-`**` (power) and `/%` (divmod) parse but aren't lowered yet — using them today panics in the lowering pass. The other arithmetic operators all work end-to-end.
+`**` lowers to integer-only square-and-multiply on i64. Float operands (e.g. `2.0 ** 0.5`) need `exp` / `ln` math primitives — blocked on a `std/float.wat` that doesn't exist yet.
 
 ## Ordering operator (`<=>`)
 

--- a/content/index.md
+++ b/content/index.md
@@ -3,12 +3,14 @@ template: home
 ---
 
 ```fink
-# Pipes and partial application
-1..10
-| filter ? % 2 == 0
-| map ? * 2
-| [..?]
-|= even_nums
+{stdout, write} = import 'std/io.fnk'
+
+main = fn foo:
+  msg = match foo:
+    'ƒink': 'little bird'
+    _:      '${foo}'
+
+  write stdout, 'Hello ${msg}!'
 ```
 
 ```fink
@@ -16,12 +18,8 @@ template: home
 classify = fn match n:
   n > 0: 'positive'
   n < 0: 'negative'
-  else:  'zero'
+  _:  'zero'
+
+classify 42
 ```
 
-```fink
-# Error handling — no exceptions
-fn fetch_user id:
-  user = try get_user id
-  Ok user.name
-```

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -33,7 +33,7 @@
 //   .cmt     — comments
 //   .ph      — ? partial application placeholder
 
-use fink::ast::{CmpPart, Node, NodeKind};
+use fink::ast::{Ast, AstId, CmpPart, Node, NodeKind};
 use fink::lexer::{TokenKind, tokenize_with_seps};
 use fink::parser;
 
@@ -104,9 +104,10 @@ fn ann_range(anns: &mut Annotations, start: usize, end: usize, class: &'static s
   anns.add(start, end, class, 10);
 }
 
-fn resolve_callee<'a>(node: &'a Node<'a>) -> &'a Node<'a> {
+fn resolve_callee<'src, 'a>(ast: &'a Ast<'src>, id: AstId) -> &'a Node<'src> {
+  let node = ast.nodes.get(id);
   match &node.kind {
-    NodeKind::Member { rhs, .. } => resolve_callee(rhs),
+    NodeKind::Member { rhs, .. } => resolve_callee(ast, *rhs),
     _ => node,
   }
 }
@@ -120,15 +121,17 @@ fn br_class(depth: usize) -> &'static str {
   }
 }
 
-fn collect_ast_anns<'src>(node: &'src Node<'src>, anns: &mut Annotations, depth: usize) {
+fn collect_ast_anns<'src>(ast: &Ast<'src>, id: AstId, anns: &mut Annotations, depth: usize) {
+  let node = ast.nodes.get(id);
   match &node.kind {
 
     NodeKind::Apply { func, args } => {
-      let callee = resolve_callee(func);
+      let callee = resolve_callee(ast, *func);
       match &callee.kind {
         NodeKind::Ident(_) => {
           // Detect tagged literals: callee immediately adjacent to first arg
-          let tag_kind = args.items.first().and_then(|first_arg| {
+          let tag_kind = args.items.first().and_then(|&first_arg_id| {
+            let first_arg = ast.nodes.get(first_arg_id);
             if callee.loc.end.idx == first_arg.loc.start.idx {
               Some("tag")   // prefix: fmt'...'
             } else if first_arg.loc.end.idx == callee.loc.start.idx {
@@ -146,28 +149,30 @@ fn collect_ast_anns<'src>(node: &'src Node<'src>, anns: &mut Annotations, depth:
         }
         _ => {}
       }
-      collect_ast_anns(func, anns, depth);
-      for arg in &args.items { collect_ast_anns(arg, anns, depth); }
+      collect_ast_anns(ast, *func, anns, depth);
+      for &arg in args.items.iter() { collect_ast_anns(ast, arg, anns, depth); }
     }
 
     NodeKind::Pipe(children) => {
-      for child in &children.items {
+      for &child_id in children.items.iter() {
+        let child = ast.nodes.get(child_id);
         // Bare ident directly in pipe position is a function
         if matches!(&child.kind, NodeKind::Ident(_)) {
           ann_node(anns, child, "fn");
         }
-        collect_ast_anns(child, anns, depth);
+        collect_ast_anns(ast, child_id, anns, depth);
       }
     }
 
     NodeKind::Member { op, lhs, rhs } => {
       // Annotate the dot as op-dot
       ann_range(anns, op.loc.start.idx as usize, op.loc.end.idx as usize, "op-dot");
-      collect_ast_anns(lhs, anns, depth);
-      if matches!(&rhs.kind, NodeKind::Ident(_)) {
-        ann_node(anns, rhs, "prop");
+      collect_ast_anns(ast, *lhs, anns, depth);
+      let rhs_node = ast.nodes.get(*rhs);
+      if matches!(&rhs_node.kind, NodeKind::Ident(_)) {
+        ann_node(anns, rhs_node, "prop");
       } else {
-        collect_ast_anns(rhs, anns, depth);
+        collect_ast_anns(ast, *rhs, anns, depth);
       }
     }
 
@@ -175,16 +180,18 @@ fn collect_ast_anns<'src>(node: &'src Node<'src>, anns: &mut Annotations, depth:
       let br = br_class(depth);
       ann_range(anns, open.loc.start.idx as usize, open.loc.end.idx as usize, br);
       ann_range(anns, close.loc.start.idx as usize, close.loc.end.idx as usize, br);
-      for child in &items.items {
+      for &child_id in items.items.iter() {
+        let child = ast.nodes.get(child_id);
         if let NodeKind::Arm { lhs, body, .. } = &child.kind {
-          if matches!(&lhs.kind, NodeKind::Ident(_)) {
+          let lhs_node = ast.nodes.get(*lhs);
+          if matches!(&lhs_node.kind, NodeKind::Ident(_)) {
             // shorthand {foo} = variable ref; key:val = record key
-            ann_node(anns, lhs, if body.items.is_empty() { "ident" } else { "rec-key" });
+            ann_node(anns, lhs_node, if body.items.is_empty() { "ident" } else { "rec-key" });
           }
-          collect_ast_anns(lhs, anns, depth + 1);
-          for expr in &body.items { collect_ast_anns(expr, anns, depth + 1); }
+          collect_ast_anns(ast, *lhs, anns, depth + 1);
+          for &expr in body.items.iter() { collect_ast_anns(ast, expr, anns, depth + 1); }
         } else {
-          collect_ast_anns(child, anns, depth + 1);
+          collect_ast_anns(ast, child_id, anns, depth + 1);
         }
       }
     }
@@ -193,74 +200,82 @@ fn collect_ast_anns<'src>(node: &'src Node<'src>, anns: &mut Annotations, depth:
       let br = br_class(depth);
       ann_range(anns, open.loc.start.idx as usize, open.loc.end.idx as usize, br);
       ann_range(anns, close.loc.start.idx as usize, close.loc.end.idx as usize, br);
-      for child in &items.items { collect_ast_anns(child, anns, depth + 1); }
+      for &child in items.items.iter() { collect_ast_anns(ast, child, anns, depth + 1); }
     }
 
     NodeKind::Group { open, close, inner } => {
       let br = br_class(depth);
       ann_range(anns, open.loc.start.idx as usize, open.loc.end.idx as usize, br);
       ann_range(anns, close.loc.start.idx as usize, close.loc.end.idx as usize, br);
-      collect_ast_anns(inner, anns, depth + 1);
+      collect_ast_anns(ast, *inner, anns, depth + 1);
     }
 
     NodeKind::Block { name, params, body, .. } => {
-      if matches!(&name.kind, NodeKind::Ident(_)) {
-        ann_node(anns, name, "blk");
+      let name_node = ast.nodes.get(*name);
+      if matches!(&name_node.kind, NodeKind::Ident(_)) {
+        ann_node(anns, name_node, "blk");
       }
-      collect_ast_anns(params, anns, depth);
-      for expr in &body.items { collect_ast_anns(expr, anns, depth); }
+      collect_ast_anns(ast, *params, anns, depth);
+      for &expr in body.items.iter() { collect_ast_anns(ast, expr, anns, depth); }
     }
 
     // --- recurse-only nodes ---
 
     NodeKind::StrTempl { children, .. } | NodeKind::StrRawTempl { children, .. } => {
-      for child in children { collect_ast_anns(child, anns, depth); }
+      for &child in children.iter() { collect_ast_anns(ast, child, anns, depth); }
     }
 
-    NodeKind::Module(children) | NodeKind::Patterns(children) => {
-      for child in &children.items { collect_ast_anns(child, anns, depth); }
+    NodeKind::Module { exprs, .. } => {
+      for &child in exprs.items.iter() { collect_ast_anns(ast, child, anns, depth); }
+    }
+
+    NodeKind::Patterns(children) => {
+      for &child in children.items.iter() { collect_ast_anns(ast, child, anns, depth); }
     }
 
     NodeKind::InfixOp { lhs, rhs, .. }
     | NodeKind::Bind { lhs, rhs, .. }
     | NodeKind::BindRight { lhs, rhs, .. } => {
-      collect_ast_anns(lhs, anns, depth);
-      collect_ast_anns(rhs, anns, depth);
+      collect_ast_anns(ast, *lhs, anns, depth);
+      collect_ast_anns(ast, *rhs, anns, depth);
     }
 
     NodeKind::ChainedCmp(parts) => {
-      for part in parts {
-        if let CmpPart::Operand(n) = part { collect_ast_anns(n, anns, depth); }
+      for part in parts.iter() {
+        if let CmpPart::Operand(n) = part { collect_ast_anns(ast, *n, anns, depth); }
       }
     }
 
-    NodeKind::UnaryOp { operand, .. }
-    | NodeKind::Try(operand)
-    | NodeKind::Yield(operand) => { collect_ast_anns(operand, anns, depth); }
+    NodeKind::UnaryOp { operand, .. } | NodeKind::Try(operand) => {
+      collect_ast_anns(ast, *operand, anns, depth);
+    }
 
-    NodeKind::Spread { inner: Some(inner), .. } => { collect_ast_anns(inner, anns, depth); }
+    NodeKind::PostfixOp { lhs, .. } => { collect_ast_anns(ast, *lhs, anns, depth); }
+
+    NodeKind::Spread { inner: Some(inner), .. } => { collect_ast_anns(ast, *inner, anns, depth); }
 
     NodeKind::Fn { params, body, .. } => {
-      collect_ast_anns(params, anns, depth);
-      for expr in &body.items { collect_ast_anns(expr, anns, depth); }
+      collect_ast_anns(ast, *params, anns, depth);
+      for &expr in body.items.iter() { collect_ast_anns(ast, expr, anns, depth); }
     }
 
     NodeKind::Match { subjects, arms, .. } => {
-      for subj in &subjects.items { collect_ast_anns(subj, anns, depth); }
-      for arm in &arms.items { collect_ast_anns(arm, anns, depth); }
+      for &subj in subjects.items.iter() { collect_ast_anns(ast, subj, anns, depth); }
+      for &arm in arms.items.iter() { collect_ast_anns(ast, arm, anns, depth); }
     }
 
     NodeKind::Arm { lhs, body, .. } => {
-      collect_ast_anns(lhs, anns, depth);
-      for expr in &body.items { collect_ast_anns(expr, anns, depth); }
+      collect_ast_anns(ast, *lhs, anns, depth);
+      for &expr in body.items.iter() { collect_ast_anns(ast, expr, anns, depth); }
     }
 
     // Leaf nodes
-    NodeKind::Ident(_)
+    NodeKind::Ident(_) | NodeKind::SynthIdent(_)
     | NodeKind::LitBool(_) | NodeKind::LitInt(_)
     | NodeKind::LitFloat(_) | NodeKind::LitDecimal(_)
     | NodeKind::LitStr { .. }
     | NodeKind::Partial | NodeKind::Wildcard
+    | NodeKind::Token(_)
     | NodeKind::Spread { inner: None, .. } => {}
   }
 }
@@ -458,8 +473,8 @@ fn render(src: &str, anns: &mut Annotations) -> String {
 fn collect(src: &str) -> Annotations {
   let mut anns = Annotations::new();
   collect_lexer_anns(src, &mut anns);
-  if let Ok(parse_result) = parser::parse(src) {
-    collect_ast_anns(&parse_result.root, &mut anns, 1);
+  if let Ok(ast) = parser::parse(src, "snippet") {
+    collect_ast_anns(&ast, ast.root, &mut anns, 1);
   }
   anns
 }


### PR DESCRIPTION
## Summary

- Bumps **fink** v0.2.0 → v0.69.0 and **playground** v1.11.0 → v1.16.1
- Ports `src/highlight.rs` to fink's new arena-based AST API (`AstId` indirection, `parser::parse(src, url)`, new `PostfixOp` variant, drops obsolete `Yield` variant)
- Syncs docs against fink v0.69.0:
  - Fixes wrong int annotation (`1_234_567 # u32` → `# i32`)
  - Adds math vs bits family integer story + width rule
  - Replaces stale "Missing arithmetic operators" roadmap entry with the current "Float exponentiation" framing (`**` and `/%` work today)
  - Drops the Types section per fink's defer-types-from-spec policy
- Refreshes home-page hero examples
- Adds an open-ended range (`-3..`) example to the language reference

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes
- [x] Local dev server (`make serve`) renders all pages and playground loads v1.16.1